### PR TITLE
Fix: StartsWithCriterion List-dtype panic (v0.5.0 recovery)

### DIFF
--- a/src/yasqat/filters/criteria.py
+++ b/src/yasqat/filters/criteria.py
@@ -210,13 +210,16 @@ class StartsWithCriterion(SequenceCriterion):
         # Filter to only the first n_prefix positions per sequence
         prefix_data = data.filter(pl.col("_pos") <= n_prefix)
 
-        # Group by id, collect the prefix states as a list
+        # Join each sequence's prefix states into a single delimited string and
+        # compare strings. Comparing List-dtype columns with ``==`` panics on
+        # polars >= 1.4x ("ordering for List dtype is not supported"), so we
+        # never build a List column here. A shorter-than-target prefix yields a
+        # different string and is correctly excluded.
+        sep = "\x1f"  # unit separator — not expected in state labels
         prefixes = prefix_data.group_by(id_col, maintain_order=True).agg(
-            pl.col(state_col).alias("_prefix")
+            pl.col(state_col).str.join(sep).alias("_prefix")
         )
-
-        # Filter: prefix list must equal the target states
-        target = self.states
+        target = sep.join(self.states)
         matching = prefixes.filter(pl.col("_prefix") == target)
 
         return matching[id_col].to_list()


### PR DESCRIPTION
## Summary

Recovery for the failed v0.5.0 publish run. The publish workflow failed at the
test step: `StartsWithCriterion` compared a `List`-dtype column with `==`,
which panics on polars >= 1.4x ("not implemented: ordering for List dtype is
not supported"). Local passed only because `uv run` uses the pinned lock
(polars 1.37.1) while CI's fresh build resolved 1.42.1.

Fix joins each sequence's prefix states into a delimited string and compares
strings — no List column is built. Verified on both polars 1.37.1 and 1.42.1.

Nothing was published to PyPI (publish is gated behind tests), so v0.5.0 is
unused; its tag will be re-pointed at this fix.

## Checklist
- [x] Failure reproduced with polars 1.42.1 (4 tests)
- [x] Fixed and re-verified on 1.42.1 (26 pass) and pinned 1.37.1 (599 pass)
- [x] ruff + format + mypy clean